### PR TITLE
enable high resolution photos for android sdk 23 and higher

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/camera/models/MySize.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/models/MySize.kt
@@ -43,5 +43,7 @@ data class MySize(val width: Int, val height: Int) {
         else -> context.resources.getString(R.string.other)
     }
 
+    fun pixels() = width * height
+
     fun toSize() = Size(width, height)
 }


### PR DESCRIPTION
To get all available photo resolution the camera supports, one needs to call `getHighResolutionOutputSizes` on Android SDK 23+ Operating Systems.

This fix relates to issue #190 