### PR TITLE
Feat/camera x

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
@@ -23,6 +23,7 @@ import com.simplemobiletools.camera.R
 import com.simplemobiletools.camera.extensions.config
 import com.simplemobiletools.camera.helpers.FLASH_OFF
 import com.simplemobiletools.camera.helpers.FLASH_ON
+import com.simplemobiletools.camera.helpers.MediaOutputHelper
 import com.simplemobiletools.camera.helpers.ORIENT_LANDSCAPE_LEFT
 import com.simplemobiletools.camera.helpers.ORIENT_LANDSCAPE_RIGHT
 import com.simplemobiletools.camera.helpers.ORIENT_PORTRAIT
@@ -220,7 +221,7 @@ class MainActivity : SimpleActivity(), PhotoProcessor.MediaSavedListener, Camera
         )
 
         checkVideoCaptureIntent()
-        mPreview = CameraXPreview(this, view_finder, this)
+        mPreview = CameraXPreview(this, view_finder, MediaOutputHelper(this), this)
         checkImageCaptureIntent()
         mPreview?.setIsImageCaptureIntent(isImageCaptureIntent())
 

--- a/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
@@ -236,7 +236,7 @@ class MainActivity : SimpleActivity(), PhotoProcessor.MediaSavedListener, Camera
         mFadeHandler = Handler()
         setupPreviewImage(true)
 
-        val initialFlashlightState = config.flashlightState
+        val initialFlashlightState = FLASH_OFF
         mPreview!!.setFlashlightState(initialFlashlightState)
         updateFlashlightState(initialFlashlightState)
     }

--- a/app/src/main/kotlin/com/simplemobiletools/camera/helpers/CameraErrorHandler.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/helpers/CameraErrorHandler.kt
@@ -1,0 +1,41 @@
+package com.simplemobiletools.camera.helpers
+
+import android.content.Context
+import android.widget.Toast
+import androidx.camera.core.CameraState
+import androidx.camera.core.ImageCapture
+import androidx.camera.video.VideoRecordEvent
+import com.simplemobiletools.camera.R
+import com.simplemobiletools.commons.extensions.toast
+
+class CameraErrorHandler(
+    private val context: Context,
+) {
+
+    fun handleCameraError(error: CameraState.StateError?) {
+        when (error?.code) {
+            CameraState.ERROR_MAX_CAMERAS_IN_USE,
+            CameraState.ERROR_CAMERA_IN_USE -> context.toast(R.string.camera_in_use_error, Toast.LENGTH_LONG)
+            CameraState.ERROR_CAMERA_FATAL_ERROR -> context.toast(R.string.camera_unavailable)
+            CameraState.ERROR_STREAM_CONFIG -> context.toast(R.string.camera_configure_error)
+            CameraState.ERROR_CAMERA_DISABLED -> context.toast(R.string.camera_disabled_by_admin_error)
+            CameraState.ERROR_DO_NOT_DISTURB_MODE_ENABLED -> context.toast(R.string.camera_dnd_error, Toast.LENGTH_LONG)
+            CameraState.ERROR_OTHER_RECOVERABLE_ERROR -> {}
+        }
+    }
+
+    fun handleImageCaptureError(imageCaptureError: Int) {
+        when (imageCaptureError) {
+            ImageCapture.ERROR_FILE_IO -> context.toast(R.string.photo_not_saved)
+            else -> context.toast(R.string.photo_capture_failed)
+        }
+    }
+
+    fun handleVideoRecordingError(error: Int) {
+        when (error) {
+            VideoRecordEvent.Finalize.ERROR_INSUFFICIENT_STORAGE -> context.toast(R.string.video_capture_insufficient_storage_error)
+            VideoRecordEvent.Finalize.ERROR_NONE -> {}
+            else -> context.toast(R.string.video_recording_failed)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/camera/helpers/MediaOutputHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/helpers/MediaOutputHelper.kt
@@ -1,0 +1,210 @@
+package com.simplemobiletools.camera.helpers
+
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import android.util.Log
+import com.simplemobiletools.camera.extensions.config
+import com.simplemobiletools.camera.extensions.getOutputMediaFile
+import com.simplemobiletools.commons.activities.BaseSimpleActivity
+import com.simplemobiletools.commons.extensions.createAndroidSAFFile
+import com.simplemobiletools.commons.extensions.createDocumentUriFromRootTree
+import com.simplemobiletools.commons.extensions.createDocumentUriUsingFirstParentTreeUri
+import com.simplemobiletools.commons.extensions.createSAFFileSdk30
+import com.simplemobiletools.commons.extensions.getAndroidSAFUri
+import com.simplemobiletools.commons.extensions.getDocumentFile
+import com.simplemobiletools.commons.extensions.getDoesFilePathExist
+import com.simplemobiletools.commons.extensions.getFileOutputStreamSync
+import com.simplemobiletools.commons.extensions.getFilenameFromPath
+import com.simplemobiletools.commons.extensions.getMimeType
+import com.simplemobiletools.commons.extensions.hasProperStoredAndroidTreeUri
+import com.simplemobiletools.commons.extensions.hasProperStoredFirstParentUri
+import com.simplemobiletools.commons.extensions.hasProperStoredTreeUri
+import com.simplemobiletools.commons.extensions.isAccessibleWithSAFSdk30
+import com.simplemobiletools.commons.extensions.isRestrictedSAFOnlyRoot
+import com.simplemobiletools.commons.extensions.needsStupidWritePermissions
+import com.simplemobiletools.commons.extensions.showFileCreateError
+import java.io.File
+import java.io.OutputStream
+
+class MediaOutputHelper(private val activity: BaseSimpleActivity) {
+
+    companion object {
+        private const val TAG = "MediaOutputHelper"
+        private const val MODE = "rw"
+    }
+
+    private val mediaStorageDir = activity.config.savePhotosFolder
+
+    fun getOutputStreamMediaOutput(): MediaOutput.OutputStreamMediaOutput? {
+        val canWrite = activity.canWrite(mediaStorageDir)
+        Log.i(TAG, "getMediaOutput: canWrite=${canWrite}")
+        return if (canWrite) {
+            val path = activity.getOutputMediaFile(true)
+            val uri = activity.getUri(path)
+            uri?.let {
+                activity.getFileOutputStreamSync(path, path.getMimeType())?.let {
+                    MediaOutput.OutputStreamMediaOutput(it, uri)
+                }
+            }
+        } else {
+            null
+        }.also {
+            Log.i(TAG, "output stream: $it")
+        }
+    }
+
+    fun getFileDescriptorMediaOutput(): MediaOutput.FileDescriptorMediaOutput? {
+        val canWrite = activity.canWrite(mediaStorageDir)
+        Log.i(TAG, "getMediaOutput: canWrite=${canWrite}")
+        return if (canWrite) {
+            val path = activity.getOutputMediaFile(false)
+            val uri = activity.getUri(path)
+            uri?.let {
+                activity.getFileDescriptorSync(path, path.getMimeType())?.let {
+                    MediaOutput.FileDescriptorMediaOutput(it, uri)
+                }
+            }
+        } else {
+            null
+        }.also {
+            Log.i(TAG, "descriptor: $it")
+        }
+    }
+
+    private fun BaseSimpleActivity.canWrite(path: String): Boolean {
+        return when {
+            isRestrictedSAFOnlyRoot(path) -> hasProperStoredAndroidTreeUri(path)
+            needsStupidWritePermissions(path) -> hasProperStoredTreeUri(false)
+            isAccessibleWithSAFSdk30(path) -> hasProperStoredFirstParentUri(path)
+            else -> File(path).canWrite()
+        }
+    }
+
+    private fun BaseSimpleActivity.getUri(path: String): Uri? {
+        val targetFile = File(path)
+        return when {
+            isRestrictedSAFOnlyRoot(path) -> {
+                getAndroidSAFUri(path)
+            }
+            needsStupidWritePermissions(path) -> {
+                val parentFile = targetFile.parentFile ?: return null
+                val documentFile =
+                    if (getDoesFilePathExist(parentFile.absolutePath ?: return null)) {
+                        getDocumentFile(parentFile.path)
+                    } else {
+                        val parentDocumentFile = parentFile.parent?.let { getDocumentFile(it) }
+                        parentDocumentFile?.createDirectory(parentFile.name) ?: getDocumentFile(parentFile.absolutePath)
+                    }
+
+                if (documentFile == null) {
+                    return Uri.fromFile(targetFile)
+                }
+
+                try {
+                    if (getDoesFilePathExist(path)) {
+                        createDocumentUriFromRootTree(path)
+                    } else {
+                        documentFile.createFile(path.getMimeType(), path.getFilenameFromPath())!!.uri
+                    }
+                } catch (e: Exception) {
+                    null
+                }
+            }
+            isAccessibleWithSAFSdk30(path) -> {
+                try {
+                    createDocumentUriUsingFirstParentTreeUri(path)
+                } catch (e: Exception) {
+                    null
+                } ?: Uri.fromFile(targetFile)
+            }
+            else -> return Uri.fromFile(targetFile)
+        }
+    }
+
+    private fun BaseSimpleActivity.getFileDescriptorSync(path: String, mimeType: String): ParcelFileDescriptor? {
+        val targetFile = File(path)
+
+        return when {
+            isRestrictedSAFOnlyRoot(path) -> {
+                val uri = getAndroidSAFUri(path)
+                if (!getDoesFilePathExist(path)) {
+                    createAndroidSAFFile(path)
+                }
+                applicationContext.contentResolver.openFileDescriptor(uri, MODE)
+            }
+            needsStupidWritePermissions(path) -> {
+                val parentFile = targetFile.parentFile ?: return null
+                val documentFile =
+                    if (getDoesFilePathExist(parentFile.absolutePath ?: return null)) {
+                        getDocumentFile(parentFile.path)
+                    } else {
+                        val parentDocumentFile = parentFile.parent?.let { getDocumentFile(it) }
+                        parentDocumentFile?.createDirectory(parentFile.name) ?: getDocumentFile(parentFile.absolutePath)
+                    }
+
+
+                if (documentFile == null) {
+                    val casualOutputStream = createCasualFileDescriptor(targetFile)
+                    return if (casualOutputStream == null) {
+                        showFileCreateError(parentFile.path)
+                        null
+                    } else {
+                        casualOutputStream
+                    }
+                }
+
+                try {
+                    val uri = if (getDoesFilePathExist(path)) {
+                        createDocumentUriFromRootTree(path)
+                    } else {
+                        documentFile.createFile(mimeType, path.getFilenameFromPath())!!.uri
+                    }
+                    applicationContext.contentResolver.openFileDescriptor(uri, MODE)
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    null
+                }
+            }
+            isAccessibleWithSAFSdk30(path) -> {
+                try {
+                    val uri = createDocumentUriUsingFirstParentTreeUri(path)
+                    if (!getDoesFilePathExist(path)) {
+                        createSAFFileSdk30(path)
+                    }
+                    applicationContext.contentResolver.openFileDescriptor(uri, MODE)
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    null
+                } ?: createCasualFileDescriptor(targetFile)
+            }
+            else -> return createCasualFileDescriptor(targetFile)
+        }
+    }
+
+    private fun BaseSimpleActivity.createCasualFileDescriptor(targetFile: File): ParcelFileDescriptor? {
+        if (targetFile.parentFile?.exists() == false) {
+            targetFile.parentFile?.mkdirs()
+        }
+
+        return try {
+            contentResolver.openFileDescriptor(Uri.fromFile(targetFile), MODE)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
+    }
+
+    sealed class MediaOutput(
+        open val uri: Uri,
+    ) {
+        data class OutputStreamMediaOutput(
+            val outputStream: OutputStream,
+            override val uri: Uri,
+        ) : MediaOutput(uri)
+
+        data class FileDescriptorMediaOutput(
+            val fileDescriptor: ParcelFileDescriptor,
+            override val uri: Uri,
+        ) : MediaOutput(uri)
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreview.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreview.kt
@@ -122,7 +122,7 @@ class CameraXPreview(
     private var currentRecording: Recording? = null
     private var recordingState: VideoRecordEvent? = null
     private var cameraSelector = config.lastUsedCameraLens.toCameraSelector()
-    private var flashMode = config.flashlightState.toCameraXFlashMode()
+    private var flashMode = FLASH_MODE_OFF
     private var isPhotoCapture = config.initPhotoMode
 
     init {
@@ -357,13 +357,22 @@ class CameraXPreview(
     }
 
     override fun toggleFlashlight() {
-        val newFlashMode = when (flashMode) {
-            FLASH_MODE_OFF -> FLASH_MODE_ON
-            FLASH_MODE_ON -> FLASH_MODE_AUTO
-            FLASH_MODE_AUTO -> FLASH_MODE_OFF
-            else -> throw IllegalArgumentException("Unknown mode: $flashMode")
+        val newFlashMode = if (isPhotoCapture) {
+            when (flashMode) {
+                FLASH_MODE_OFF -> FLASH_MODE_ON
+                FLASH_MODE_ON -> FLASH_MODE_AUTO
+                FLASH_MODE_AUTO -> FLASH_MODE_OFF
+                else -> throw IllegalArgumentException("Unknown mode: $flashMode")
+            }
+        } else {
+            when (flashMode) {
+                FLASH_MODE_OFF -> FLASH_MODE_ON
+                FLASH_MODE_ON -> FLASH_MODE_OFF
+                else -> throw IllegalArgumentException("Unknown mode: $flashMode")
+            }.also {
+                camera?.cameraControl?.enableTorch(it == FLASH_MODE_ON)
+            }
         }
-
         flashMode = newFlashMode
         imageCapture?.flashMode = newFlashMode
         val appFlashMode = flashMode.toAppFlashMode()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,8 @@
 <resources>
     <string name="app_name">Simple Camera</string>
     <string name="app_launcher_name">Camera</string>
+
+    <!--Errors-->
     <string name="camera_unavailable">Camera unavailable</string>
     <string name="camera_open_error">An error occurred accessing the camera</string>
     <string name="video_creating_error">An error occurred creating the video file</string>
@@ -12,6 +14,15 @@
     <string name="photo_not_saved">The photo could not be saved</string>
     <string name="setting_resolution_failed">Setting proper resolution failed</string>
     <string name="video_recording_failed">Video recording failed, try using a different resolution</string>
+
+    <!--TODO: Add strings in other locales-->
+    <string name="camera_in_use_error">Camera is in use by another app, please close the app and try again</string>
+    <string name="camera_configure_error">An error occurred while configuring the camera</string>
+    <string name="camera_disabled_by_admin_error">Camera is disabled by the admin</string>
+    <string name="camera_dnd_error">"Do Not Disturb" mode is enabled. Please disable and try again</string>
+
+    <string name="photo_capture_failed">Photo capture failed</string>
+    <string name="video_capture_insufficient_storage_error">Video recording failed due to insufficient storage</string>
 
     <!-- FAQ -->
     <string name="faq_1_title">What photo compression quality should I set?</string>


### PR DESCRIPTION
## Notes
- to handle the media storage location:
   - add `MediaOutputHelper`
       - to create `OutputStream` for photos
       - to create `FileDescriptor` for videos (currently requires API 26+). The API might change
- handle torch state in video capture
- handle some camera errors (documented [here](https://lumpy-scorpion-7f2.notion.site/7af8a3211de0424ea39f50b777684694?v=2cd1b330205743efa92e2ac599e7e183))
    - errors during camera lifecycle
    - when capturing images
    - when recording videos