### PR TITLE
Feat/camera x

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/camera/helpers/ExifRemover.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/helpers/ExifRemover.kt
@@ -1,0 +1,26 @@
+package com.simplemobiletools.camera.helpers
+
+import android.content.ContentResolver
+import android.net.Uri
+import androidx.annotation.WorkerThread
+import androidx.exifinterface.media.ExifInterface
+import com.simplemobiletools.commons.extensions.removeValues
+import java.io.IOException
+
+class ExifRemover(private val contentResolver: ContentResolver) {
+    companion object {
+        private const val MODE = "rw"
+    }
+
+    @WorkerThread
+    fun removeExif(uri: Uri) {
+        try {
+            val fileDescriptor = contentResolver.openFileDescriptor(uri, MODE)
+            if (fileDescriptor != null) {
+                val exifInterface = ExifInterface(fileDescriptor.fileDescriptor)
+                exifInterface.removeValues()
+            }
+        } catch (e: IOException) {
+        }
+    }
+}


### PR DESCRIPTION
## Notes
- properly ensure `RECORD_AUDIO` permission is requested during camera initialisation
   - since `allowBackup` is set to true in the manifest,
   - it is possible for the app to be launched after a fresh install with `mIsInPhotoMode=true` in `MainActivity`
   - this commit ensures the audio permission is requested at this point
   - if the user denies it, then it is initialised in photo mode instead

- remove EXIF info after image capture if the user sets `config.savePhotoMetadata == false`