### PR TITLE
Updates/Fixes for CameraX implementation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,13 +62,13 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.SimpleMobileTools:Simple-Commons:d1d5402388'
+    implementation 'com.github.SimpleMobileTools:Simple-Commons:7c48da6bef'
     implementation 'androidx.documentfile:documentfile:1.0.1'
     implementation "androidx.exifinterface:exifinterface:1.3.3"
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.1"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.5.0"
     implementation 'androidx.window:window:1.1.0-alpha02'
 
-    def camerax_version = '1.1.0-rc02'
+    def camerax_version = '1.1.0'
     implementation "androidx.camera:camera-core:$camerax_version"
     implementation "androidx.camera:camera-camera2:$camerax_version"
     implementation "androidx.camera:camera-video:$camerax_version"

--- a/app/src/main/kotlin/com/simplemobiletools/camera/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/activities/SettingsActivity.kt
@@ -10,10 +10,11 @@ import com.simplemobiletools.commons.dialogs.FilePickerDialog
 import com.simplemobiletools.commons.dialogs.RadioGroupDialog
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.LICENSE_GLIDE
+import com.simplemobiletools.commons.helpers.NavigationIcon
 import com.simplemobiletools.commons.models.FAQItem
 import com.simplemobiletools.commons.models.RadioItem
+import java.util.Locale
 import kotlinx.android.synthetic.main.activity_settings.*
-import java.util.*
 
 class SettingsActivity : SimpleActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -23,7 +24,7 @@ class SettingsActivity : SimpleActivity() {
 
     override fun onResume() {
         super.onResume()
-
+        setupToolbar(settings_toolbar, NavigationIcon.Arrow)
         setupPurchaseThankYou()
         setupCustomizeColors()
         setupUseEnglish()

--- a/app/src/main/kotlin/com/simplemobiletools/camera/dialogs/ChangeResolutionDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/dialogs/ChangeResolutionDialog.kt
@@ -8,13 +8,19 @@ import com.simplemobiletools.camera.activities.SimpleActivity
 import com.simplemobiletools.camera.extensions.config
 import com.simplemobiletools.camera.models.MySize
 import com.simplemobiletools.commons.dialogs.RadioGroupDialog
+import com.simplemobiletools.commons.extensions.getAlertDialogBuilder
 import com.simplemobiletools.commons.extensions.setupDialogStuff
 import com.simplemobiletools.commons.models.RadioItem
-import kotlinx.android.synthetic.main.dialog_change_resolution.view.*
+import kotlinx.android.synthetic.main.dialog_change_resolution.view.change_resolution_photo
+import kotlinx.android.synthetic.main.dialog_change_resolution.view.change_resolution_photo_holder
+import kotlinx.android.synthetic.main.dialog_change_resolution.view.change_resolution_video
+import kotlinx.android.synthetic.main.dialog_change_resolution.view.change_resolution_video_holder
 
-class ChangeResolutionDialog(val activity: SimpleActivity, val isFrontCamera: Boolean, val photoResolutions: ArrayList<MySize>,
-                             val videoResolutions: ArrayList<MySize>, val openVideoResolutions: Boolean, val callback: () -> Unit) {
-    private var dialog: AlertDialog
+class ChangeResolutionDialog(
+    val activity: SimpleActivity, val isFrontCamera: Boolean, val photoResolutions: ArrayList<MySize>,
+    val videoResolutions: ArrayList<MySize>, val openVideoResolutions: Boolean, val callback: () -> Unit
+) {
+    private var dialog: AlertDialog? = null
     private val config = activity.config
 
     init {
@@ -23,16 +29,17 @@ class ChangeResolutionDialog(val activity: SimpleActivity, val isFrontCamera: Bo
             setupVideoResolutionPicker(this)
         }
 
-        dialog = AlertDialog.Builder(activity)
-                .setPositiveButton(R.string.ok, null)
-                .setOnDismissListener { callback() }
-                .create().apply {
-                    activity.setupDialogStuff(view, this, if (isFrontCamera) R.string.front_camera else R.string.back_camera) {
-                        if (openVideoResolutions) {
-                            view.change_resolution_video_holder.performClick()
-                        }
+        activity.getAlertDialogBuilder()
+            .setPositiveButton(R.string.ok, null)
+            .setOnDismissListener { callback() }
+            .apply {
+                activity.setupDialogStuff(view, this, if (isFrontCamera) R.string.front_camera else R.string.back_camera) {
+                    dialog = it
+                    if (openVideoResolutions) {
+                        view.change_resolution_video_holder.performClick()
                     }
                 }
+            }
     }
 
     private fun setupPhotoResolutionPicker(view: View) {
@@ -49,7 +56,7 @@ class ChangeResolutionDialog(val activity: SimpleActivity, val isFrontCamera: Bo
                 } else {
                     config.backPhotoResIndex = it
                 }
-                dialog.dismiss()
+                dialog?.dismiss()
             }
         }
         view.change_resolution_photo.text = items.getOrNull(selectionIndex)?.title
@@ -68,7 +75,7 @@ class ChangeResolutionDialog(val activity: SimpleActivity, val isFrontCamera: Bo
                 } else {
                     config.backVideoResIndex = it
                 }
-                dialog.dismiss()
+                dialog?.dismiss()
             }
         }
         view.change_resolution_video.text = items.getOrNull(selectionIndex)?.title

--- a/app/src/main/kotlin/com/simplemobiletools/camera/dialogs/ChangeResolutionDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/dialogs/ChangeResolutionDialog.kt
@@ -33,8 +33,9 @@ class ChangeResolutionDialog(
             .setPositiveButton(R.string.ok, null)
             .setOnDismissListener { callback() }
             .apply {
-                activity.setupDialogStuff(view, this, if (isFrontCamera) R.string.front_camera else R.string.back_camera) {
-                    dialog = it
+                val titleId = if (isFrontCamera) R.string.front_camera else R.string.back_camera
+                activity.setupDialogStuff(view, this, titleId) { alertDialog ->
+                    dialog = alertDialog
                     if (openVideoResolutions) {
                         view.change_resolution_video_holder.performClick()
                     }

--- a/app/src/main/kotlin/com/simplemobiletools/camera/dialogs/ChangeResolutionDialogX.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/dialogs/ChangeResolutionDialogX.kt
@@ -42,7 +42,7 @@ class ChangeResolutionDialogX(
     }
 
     private fun setupPhotoResolutionPicker(view: View) {
-        val items = photoResolutions.mapIndexed { index, resolution->
+        val items = photoResolutions.mapIndexed { index, resolution ->
             val megapixels = resolution.megaPixels
             val aspectRatio = resolution.getAspectRatio(activity)
             RadioItem(index, "${resolution.width} x ${resolution.height}  ($megapixels MP,  $aspectRatio)")
@@ -74,24 +74,27 @@ class ChangeResolutionDialogX(
             RadioItem(index, "${videoQuality.width} x ${videoQuality.height}  ($megapixels MP,  $aspectRatio)")
         }
 
-        val videoQuality = if (isFrontCamera) config.frontVideoQuality else config.backVideoQuality
-        var selectionIndex = videoResolutions.indexOf(videoQuality)
+        var selectionIndex = if (isFrontCamera) config.frontVideoResIndex else config.backVideoResIndex
+        selectionIndex = selectionIndex.coerceAtLeast(0)
+        Log.i(TAG, "videoResolutions=$videoResolutions")
+        Log.i(TAG, "setupVideoResolutionPicker: selectionIndex=$selectionIndex")
 
         view.change_resolution_video_holder.setOnClickListener {
             RadioGroupDialog(activity, ArrayList(items), selectionIndex) {
                 selectionIndex = it as Int
                 val selectedItem = items[selectionIndex]
-                val selectedQuality = videoResolutions[selectionIndex]
                 view.change_resolution_video.text = selectedItem.title
                 if (isFrontCamera) {
-                    config.frontVideoQuality = selectedQuality
+                    config.frontVideoResIndex = selectionIndex
                 } else {
-                    config.backVideoQuality = selectedQuality
+                    config.backPhotoResIndex = selectionIndex
                 }
                 dialog.dismiss()
                 callback.invoke()
             }
         }
-        view.change_resolution_video.text = items.getOrNull(selectionIndex)?.title
+        val selectedItem = items.getOrNull(selectionIndex)
+        view.change_resolution_video.text = selectedItem?.title
+        Log.i(TAG, "setupVideoResolutionPicker: selectedItem=$selectedItem")
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/camera/dialogs/ChangeResolutionDialogX.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/dialogs/ChangeResolutionDialogX.kt
@@ -10,6 +10,7 @@ import com.simplemobiletools.camera.extensions.config
 import com.simplemobiletools.camera.models.MySize
 import com.simplemobiletools.camera.models.VideoQuality
 import com.simplemobiletools.commons.dialogs.RadioGroupDialog
+import com.simplemobiletools.commons.extensions.getAlertDialogBuilder
 import com.simplemobiletools.commons.extensions.setupDialogStuff
 import com.simplemobiletools.commons.models.RadioItem
 import kotlinx.android.synthetic.main.dialog_change_resolution.view.change_resolution_photo
@@ -24,7 +25,7 @@ class ChangeResolutionDialogX(
     private val videoResolutions: List<VideoQuality>,
     private val callback: () -> Unit,
 ) {
-    private var dialog: AlertDialog
+    private var dialog: AlertDialog? = null
     private val config = activity.config
 
     private val TAG = "ChangeResolutionDialogX"
@@ -34,10 +35,12 @@ class ChangeResolutionDialogX(
             setupVideoResolutionPicker(this)
         }
 
-        dialog = AlertDialog.Builder(activity)
+        activity.getAlertDialogBuilder()
             .setPositiveButton(R.string.ok, null)
-            .create().apply {
-                activity.setupDialogStuff(view, this, if (isFrontCamera) R.string.front_camera else R.string.back_camera)
+            .apply {
+                activity.setupDialogStuff(view, this, if (isFrontCamera) R.string.front_camera else R.string.back_camera){
+                    dialog = it
+                }
             }
     }
 
@@ -60,7 +63,7 @@ class ChangeResolutionDialogX(
                 } else {
                     config.backPhotoResIndex = it
                 }
-                dialog.dismiss()
+                dialog?.dismiss()
                 callback.invoke()
             }
         }
@@ -89,7 +92,7 @@ class ChangeResolutionDialogX(
                 } else {
                     config.backPhotoResIndex = selectionIndex
                 }
-                dialog.dismiss()
+                dialog?.dismiss()
                 callback.invoke()
             }
         }

--- a/app/src/main/kotlin/com/simplemobiletools/camera/dialogs/ChangeResolutionDialogX.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/dialogs/ChangeResolutionDialogX.kt
@@ -22,7 +22,7 @@ class ChangeResolutionDialogX(
     private val isFrontCamera: Boolean,
     private val photoResolutions: List<MySize> = listOf(),
     private val videoResolutions: List<VideoQuality>,
-    private val callback: () -> Unit
+    private val callback: () -> Unit,
 ) {
     private var dialog: AlertDialog
     private val config = activity.config
@@ -42,12 +42,16 @@ class ChangeResolutionDialogX(
     }
 
     private fun setupPhotoResolutionPicker(view: View) {
-        val items = getFormattedResolutions(photoResolutions)
+        val items = photoResolutions.mapIndexed { index, resolution->
+            val megapixels = resolution.megaPixels
+            val aspectRatio = resolution.getAspectRatio(activity)
+            RadioItem(index, "${resolution.width} x ${resolution.height}  ($megapixels MP,  $aspectRatio)")
+        }
         var selectionIndex = if (isFrontCamera) config.frontPhotoResIndex else config.backPhotoResIndex
-        selectionIndex = Math.max(selectionIndex, 0)
+        selectionIndex = selectionIndex.coerceAtLeast(0)
 
         view.change_resolution_photo_holder.setOnClickListener {
-            RadioGroupDialog(activity, items, selectionIndex) {
+            RadioGroupDialog(activity, ArrayList(items), selectionIndex) {
                 selectionIndex = it as Int
                 Log.w(TAG, "setupPhotoResolutionPicker: selectionIndex=$it")
                 view.change_resolution_photo.text = items[selectionIndex].title
@@ -89,16 +93,5 @@ class ChangeResolutionDialogX(
             }
         }
         view.change_resolution_video.text = items.getOrNull(selectionIndex)?.title
-    }
-
-    private fun getFormattedResolutions(resolutions: List<MySize>): ArrayList<RadioItem> {
-        val items = ArrayList<RadioItem>(resolutions.size)
-        val sorted = resolutions.sortedByDescending { it.width * it.height }
-        sorted.forEachIndexed { index, size ->
-            val megapixels = String.format("%.1f", (size.width * size.height.toFloat()) / 1000000)
-            val aspectRatio = size.getAspectRatio(activity)
-            items.add(RadioItem(index, "${size.width} x ${size.height}  ($megapixels MP,  $aspectRatio)"))
-        }
-        return items
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/camera/dialogs/ChangeResolutionDialogX.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/dialogs/ChangeResolutionDialogX.kt
@@ -38,8 +38,9 @@ class ChangeResolutionDialogX(
         activity.getAlertDialogBuilder()
             .setPositiveButton(R.string.ok, null)
             .apply {
-                activity.setupDialogStuff(view, this, if (isFrontCamera) R.string.front_camera else R.string.back_camera){
-                    dialog = it
+                val titleId = if (isFrontCamera) R.string.front_camera else R.string.back_camera
+                activity.setupDialogStuff(view, this, titleId) { alertDialog ->
+                    dialog = alertDialog
                 }
             }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/camera/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/helpers/Config.kt
@@ -3,7 +3,6 @@ package com.simplemobiletools.camera.helpers
 import android.content.Context
 import android.os.Environment
 import androidx.camera.core.CameraSelector
-import com.simplemobiletools.camera.models.VideoQuality
 import com.simplemobiletools.commons.helpers.BaseConfig
 import java.io.File
 
@@ -62,20 +61,6 @@ class Config(context: Context) : BaseConfig(context) {
     var frontPhotoResIndex: Int
         get() = prefs.getInt(FRONT_PHOTO_RESOLUTION_INDEX, 0)
         set(frontPhotoResIndex) = prefs.edit().putInt(FRONT_PHOTO_RESOLUTION_INDEX, frontPhotoResIndex).apply()
-
-    var backVideoQuality: VideoQuality
-        get() {
-            val backQuality = prefs.getString(BACK_VIDEO_QUALITY, VideoQuality.UHD.name)
-            return VideoQuality.values().first { it.name == backQuality }
-        }
-        set(backVideoQuality) = prefs.edit().putString(BACK_VIDEO_QUALITY, backVideoQuality.name).apply()
-
-    var frontVideoQuality: VideoQuality
-        get() {
-            val frontQuality = prefs.getString(FRONT_VIDEO_QUALITY, VideoQuality.UHD.name)
-            return VideoQuality.values().first { it.name == frontQuality }
-        }
-        set(frontVideoQuality) = prefs.edit().putString(FRONT_VIDEO_QUALITY, frontVideoQuality.name).apply()
 
     var frontVideoResIndex: Int
         get() = prefs.getInt(FRONT_VIDEO_RESOLUTION_INDEX, 0)

--- a/app/src/main/kotlin/com/simplemobiletools/camera/helpers/ImageQualityManager.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/helpers/ImageQualityManager.kt
@@ -10,11 +10,8 @@ import android.util.Log
 import android.util.Size
 import androidx.appcompat.app.AppCompatActivity
 import androidx.camera.core.CameraSelector
-import androidx.camera.video.Quality
 import com.simplemobiletools.camera.extensions.config
-import com.simplemobiletools.camera.extensions.toCameraXQuality
 import com.simplemobiletools.camera.models.CameraSelectorImageQualities
-import com.simplemobiletools.camera.models.CameraSelectorVideoQualities
 import com.simplemobiletools.camera.models.MySize
 
 class ImageQualityManager(
@@ -69,7 +66,7 @@ class ImageQualityManager(
         val index = if (cameraSelector == CameraSelector.DEFAULT_FRONT_CAMERA) config.frontPhotoResIndex else config.backPhotoResIndex
         return imageQualities.filter { it.camSelector == cameraSelector }
             .flatMap { it.qualities }
-            .sortedByDescending { it.pixels}
+            .sortedByDescending { it.pixels }
             .distinctBy { it.pixels }
             .map { Size(it.width, it.height) }
             .also {
@@ -85,5 +82,6 @@ class ImageQualityManager(
             .flatMap { it.qualities }
             .sortedByDescending { it.pixels }
             .distinctBy { it.pixels }
+            .filter { it.megaPixels != "0.0" }
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/camera/helpers/VideoQualityManager.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/helpers/VideoQualityManager.kt
@@ -34,6 +34,7 @@ class VideoQualityManager(private val config: Config) {
                             .also { allQualities ->
                                 val qualities = allQualities.map { it.toVideoQuality() }
                                 videoQualities.add(CameraSelectorVideoQualities(camSelector, qualities))
+
                             }
                         Log.i(TAG, "bindCameraUseCases: videoQualities=$videoQualities")
                     }
@@ -45,11 +46,9 @@ class VideoQualityManager(private val config: Config) {
     }
 
     fun getUserSelectedQuality(cameraSelector: CameraSelector): Quality {
-        return if (cameraSelector == CameraSelector.DEFAULT_FRONT_CAMERA) {
-            config.frontVideoQuality.toCameraXQuality()
-        } else {
-            config.backVideoQuality.toCameraXQuality()
-        }
+        var selectionIndex = if (cameraSelector == CameraSelector.DEFAULT_FRONT_CAMERA) config.frontVideoResIndex else config.backVideoResIndex
+        selectionIndex = selectionIndex.coerceAtLeast(0)
+        return getSupportedQualities(cameraSelector)[selectionIndex].toCameraXQuality()
     }
 
     fun getSupportedQualities(cameraSelector: CameraSelector): List<VideoQuality> {

--- a/app/src/main/kotlin/com/simplemobiletools/camera/helpers/VideoQualityManager.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/helpers/VideoQualityManager.kt
@@ -6,6 +6,7 @@ import androidx.camera.core.CameraSelector
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.video.Quality
 import androidx.camera.video.QualitySelector
+import com.simplemobiletools.camera.extensions.config
 import com.simplemobiletools.camera.extensions.toCameraXQuality
 import com.simplemobiletools.camera.extensions.toVideoQuality
 import com.simplemobiletools.camera.models.CameraSelectorVideoQualities
@@ -13,7 +14,6 @@ import com.simplemobiletools.camera.models.VideoQuality
 
 class VideoQualityManager(
     private val activity: AppCompatActivity,
-    private val config: Config,
 ) {
 
     companion object {
@@ -22,6 +22,7 @@ class VideoQualityManager(
         private val CAMERA_SELECTORS = arrayOf(CameraSelector.DEFAULT_BACK_CAMERA, CameraSelector.DEFAULT_FRONT_CAMERA)
     }
 
+    private val config = activity.config
     private val videoQualities = mutableListOf<CameraSelectorVideoQualities>()
 
     fun initSupportedQualities(cameraProvider: ProcessCameraProvider) {

--- a/app/src/main/kotlin/com/simplemobiletools/camera/helpers/VideoQualityManager.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/helpers/VideoQualityManager.kt
@@ -1,7 +1,7 @@
 package com.simplemobiletools.camera.helpers
 
 import android.util.Log
-import androidx.camera.core.Camera
+import androidx.appcompat.app.AppCompatActivity
 import androidx.camera.core.CameraSelector
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.video.Quality
@@ -11,7 +11,10 @@ import com.simplemobiletools.camera.extensions.toVideoQuality
 import com.simplemobiletools.camera.models.CameraSelectorVideoQualities
 import com.simplemobiletools.camera.models.VideoQuality
 
-class VideoQualityManager(private val config: Config) {
+class VideoQualityManager(
+    private val activity: AppCompatActivity,
+    private val config: Config,
+) {
 
     companion object {
         private const val TAG = "VideoQualityHelper"
@@ -21,12 +24,11 @@ class VideoQualityManager(private val config: Config) {
 
     private val videoQualities = mutableListOf<CameraSelectorVideoQualities>()
 
-    fun initSupportedQualities(
-        cameraProvider: ProcessCameraProvider,
-        camera: Camera,
-    ) {
+    fun initSupportedQualities(cameraProvider: ProcessCameraProvider) {
         if (videoQualities.isEmpty()) {
             for (camSelector in CAMERA_SELECTORS) {
+                cameraProvider.unbindAll()
+                val camera = cameraProvider.bindToLifecycle(activity, camSelector)
                 try {
                     if (cameraProvider.hasCamera(camSelector)) {
                         QualitySelector.getSupportedQualities(camera.cameraInfo)

--- a/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreview.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreview.kt
@@ -223,7 +223,7 @@ class CameraXPreview(
     private fun buildVideoCapture(): VideoCapture<Recorder> {
         val qualitySelector = QualitySelector.from(
             videoQualityManager.getUserSelectedQuality(cameraSelector),
-            FallbackStrategy.lowerQualityOrHigherThan(Quality.SD),
+            FallbackStrategy.higherQualityOrLowerThan(Quality.SD),
         )
         val recorder = Recorder.Builder()
             .setQualitySelector(qualitySelector)

--- a/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreview.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreview.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.hardware.SensorManager
 import android.hardware.display.DisplayManager
 import android.util.Log
+import android.util.Size
 import android.view.*
 import android.view.GestureDetector.SimpleOnGestureListener
 import androidx.appcompat.app.AppCompatActivity
@@ -74,7 +75,7 @@ class CameraXPreview(
                 in 225 until 315 -> Surface.ROTATION_90
                 else -> Surface.ROTATION_0
             }
-
+            Log.i(TAG, "onOrientationChanged: rotation=$rotation")
             preview?.targetRotation = rotation
             imageCapture?.targetRotation = rotation
             videoCapture?.targetRotation = rotation
@@ -194,11 +195,22 @@ class CameraXPreview(
             .setTargetRotation(rotation)
             .apply {
                 imageQualityManager.getUserSelectedResolution(cameraSelector)?.let { resolution ->
+                    val rotatedResolution = getRotatedResolution(rotation, resolution)
+                    Log.i(TAG, "buildImageCapture: rotation=$rotation")
                     Log.i(TAG, "buildImageCapture: resolution=$resolution")
-                    setTargetResolution(resolution)
+                    Log.i(TAG, "buildImageCapture: rotatedResolution=$rotatedResolution")
+                    setTargetResolution(rotatedResolution)
                 } ?: setTargetAspectRatio(aspectRatio)
             }
             .build()
+    }
+
+    private fun getRotatedResolution(rotationDegrees: Int, resolution: Size): Size {
+        return if (rotationDegrees == Surface.ROTATION_0 || rotationDegrees == Surface.ROTATION_180) {
+            Size(resolution.height, resolution.width)
+        } else {
+            Size(resolution.width, resolution.height)
+        }
     }
 
     private fun buildPreview(aspectRatio: Int, rotation: Int): Preview {

--- a/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreview.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreview.kt
@@ -58,7 +58,7 @@ class CameraXPreview(
     private val displayManager = activity.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
     private val mediaSoundHelper = MediaSoundHelper()
     private val windowMetricsCalculator = WindowMetricsCalculator.getOrCreate()
-    private val videoQualityManager = VideoQualityManager(activity, config)
+    private val videoQualityManager = VideoQualityManager(activity)
     private val imageQualityManager = ImageQualityManager(activity)
     private val exifRemover = ExifRemover(contentResolver)
 

--- a/app/src/main/kotlin/com/simplemobiletools/camera/models/MySize.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/models/MySize.kt
@@ -5,8 +5,16 @@ import android.util.Size
 import com.simplemobiletools.camera.R
 
 data class MySize(val width: Int, val height: Int) {
+    companion object {
+        private const val ONE_MEGA_PIXEL = 1000000
+    }
+
     val ratio = width / height.toFloat()
+
     val pixels: Int = width * height
+
+    val megaPixels: String =  String.format("%.1f", (width * height.toFloat()) / ONE_MEGA_PIXEL)
+
     fun isSixteenToNine() = ratio == 16 / 9f
 
     private fun isFiveToThree() = ratio == 5 / 3f

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,254 +1,283 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/settings_scrollview"
+    android:id="@+id/settings_coordinator"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="match_parent">
 
-    <LinearLayout
-        android:id="@+id/settings_holder"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/settings_app_bar_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:layout_height="wrap_content">
 
-        <TextView
-            android:id="@+id/settings_color_customization_label"
-            style="@style/SettingsSectionLabelStyle"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/settings_toolbar"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/color_customization" />
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/color_primary"
+            app:layout_scrollFlags="scroll|enterAlways"
+            app:title="@string/settings"
+            app:titleTextAppearance="@style/AppTheme.ActionBar.TitleTextStyle" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/settings_nested_scrollview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true"
+        android:scrollbars="none"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
 
         <LinearLayout
-            android:id="@+id/settings_color_customization_holder"
+            android:id="@+id/settings_holder"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/medium_margin"
-            android:background="@drawable/section_holder_stroke"
             android:orientation="vertical">
 
-            <RelativeLayout
-                android:id="@+id/settings_customize_colors_holder"
-                style="@style/SettingsHolderTextViewOneLinerStyle"
+            <TextView
+                android:id="@+id/settings_color_customization_label"
+                style="@style/SettingsSectionLabelStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@drawable/ripple_all_corners">
+                android:text="@string/color_customization" />
 
-                <com.simplemobiletools.commons.views.MyTextView
-                    android:id="@+id/settings_customize_colors_label"
-                    style="@style/SettingsTextLabelStyle"
-                    android:layout_width="wrap_content"
+            <LinearLayout
+                android:id="@+id/settings_color_customization_holder"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/medium_margin"
+                android:background="@drawable/section_holder_stroke"
+                android:orientation="vertical">
+
+                <RelativeLayout
+                    android:id="@+id/settings_customize_colors_holder"
+                    style="@style/SettingsHolderTextViewOneLinerStyle"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/customize_colors" />
+                    android:background="@drawable/ripple_all_corners">
 
-            </RelativeLayout>
+                    <com.simplemobiletools.commons.views.MyTextView
+                        android:id="@+id/settings_customize_colors_label"
+                        style="@style/SettingsTextLabelStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/customize_colors" />
+
+                </RelativeLayout>
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/settings_general_settings_label"
+                style="@style/SettingsSectionLabelStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/general_settings" />
+
+            <LinearLayout
+                android:id="@+id/settings_general_settings_holder"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/medium_margin"
+                android:background="@drawable/section_holder_stroke"
+                android:orientation="vertical">
+
+                <RelativeLayout
+                    android:id="@+id/settings_purchase_thank_you_holder"
+                    style="@style/SettingsHolderTextViewOneLinerStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/ripple_top_corners">
+
+                    <com.simplemobiletools.commons.views.MyTextView
+                        android:id="@+id/settings_purchase_thank_you"
+                        style="@style/SettingsTextLabelStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/purchase_simple_thank_you" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:id="@+id/settings_use_english_holder"
+                    style="@style/SettingsHolderCheckboxStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/ripple_background">
+
+                    <com.simplemobiletools.commons.views.MyAppCompatCheckbox
+                        android:id="@+id/settings_use_english"
+                        style="@style/SettingsCheckboxStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/use_english_language" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:id="@+id/settings_keep_settings_visible_holder"
+                    style="@style/SettingsHolderCheckboxStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/ripple_bottom_corners">
+
+                    <com.simplemobiletools.commons.views.MyAppCompatCheckbox
+                        android:id="@+id/settings_keep_settings_visible"
+                        style="@style/SettingsCheckboxStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/keep_settings_visible" />
+
+                </RelativeLayout>
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/settings_shutter_label"
+                style="@style/SettingsSectionLabelStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/shutter" />
+
+            <LinearLayout
+                android:id="@+id/settings_shutter_holder"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/medium_margin"
+                android:background="@drawable/section_holder_stroke"
+                android:orientation="vertical">
+
+                <RelativeLayout
+                    android:id="@+id/settings_sound_holder"
+                    style="@style/SettingsHolderCheckboxStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/ripple_top_corners">
+
+                    <com.simplemobiletools.commons.views.MyAppCompatCheckbox
+                        android:id="@+id/settings_sound"
+                        style="@style/SettingsCheckboxStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/shutter_sound" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:id="@+id/settings_volume_buttons_as_shutter_holder"
+                    style="@style/SettingsHolderCheckboxStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/ripple_bottom_corners">
+
+                    <com.simplemobiletools.commons.views.MyAppCompatCheckbox
+                        android:id="@+id/settings_volume_buttons_as_shutter"
+                        style="@style/SettingsCheckboxStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/volume_buttons_as_shutter" />
+
+                </RelativeLayout>
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/settings_saving_label"
+                style="@style/SettingsSectionLabelStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/saving_label" />
+
+            <LinearLayout
+                android:id="@+id/settings_saving_holder"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/medium_margin"
+                android:background="@drawable/section_holder_stroke"
+                android:orientation="vertical">
+
+                <RelativeLayout
+                    android:id="@+id/settings_save_photo_metadata_holder"
+                    style="@style/SettingsHolderCheckboxStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/ripple_top_corners">
+
+                    <com.simplemobiletools.commons.views.MyAppCompatCheckbox
+                        android:id="@+id/settings_save_photo_metadata"
+                        style="@style/SettingsCheckboxStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/save_photo_metadata" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:id="@+id/settings_flip_photos_holder"
+                    style="@style/SettingsHolderCheckboxStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/ripple_background">
+
+                    <com.simplemobiletools.commons.views.MyAppCompatCheckbox
+                        android:id="@+id/settings_flip_photos"
+                        style="@style/SettingsCheckboxStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/flip_front_camera_photos_horizontally" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:id="@+id/settings_save_photos_holder"
+                    style="@style/SettingsHolderTextViewStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/ripple_background">
+
+                    <com.simplemobiletools.commons.views.MyTextView
+                        android:id="@+id/settings_save_photos_label"
+                        style="@style/SettingsTextLabelStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/save_photos" />
+
+                    <com.simplemobiletools.commons.views.MyTextView
+                        android:id="@+id/settings_save_photos"
+                        style="@style/SettingsTextValueStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@+id/settings_save_photos_label"
+                        tools:text="Internal/DCIM" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:id="@+id/settings_photo_quality_holder"
+                    style="@style/SettingsHolderTextViewStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/ripple_bottom_corners">
+
+                    <com.simplemobiletools.commons.views.MyTextView
+                        android:id="@+id/settings_photo_quality_label"
+                        style="@style/SettingsTextLabelStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/photo_compression_quality" />
+
+                    <com.simplemobiletools.commons.views.MyTextView
+                        android:id="@+id/settings_photo_quality"
+                        style="@style/SettingsTextValueStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@+id/settings_photo_quality_label"
+                        tools:text="80%" />
+
+                </RelativeLayout>
+            </LinearLayout>
         </LinearLayout>
 
-        <TextView
-            android:id="@+id/settings_general_settings_label"
-            style="@style/SettingsSectionLabelStyle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/general_settings" />
+    </androidx.core.widget.NestedScrollView>
 
-        <LinearLayout
-            android:id="@+id/settings_general_settings_holder"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/medium_margin"
-            android:background="@drawable/section_holder_stroke"
-            android:orientation="vertical">
-
-            <RelativeLayout
-                android:id="@+id/settings_purchase_thank_you_holder"
-                style="@style/SettingsHolderTextViewOneLinerStyle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@drawable/ripple_top_corners">
-
-                <com.simplemobiletools.commons.views.MyTextView
-                    android:id="@+id/settings_purchase_thank_you"
-                    style="@style/SettingsTextLabelStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/purchase_simple_thank_you" />
-
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:id="@+id/settings_use_english_holder"
-                style="@style/SettingsHolderCheckboxStyle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@drawable/ripple_background">
-
-                <com.simplemobiletools.commons.views.MyAppCompatCheckbox
-                    android:id="@+id/settings_use_english"
-                    style="@style/SettingsCheckboxStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/use_english_language" />
-
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:id="@+id/settings_keep_settings_visible_holder"
-                style="@style/SettingsHolderCheckboxStyle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@drawable/ripple_bottom_corners">
-
-                <com.simplemobiletools.commons.views.MyAppCompatCheckbox
-                    android:id="@+id/settings_keep_settings_visible"
-                    style="@style/SettingsCheckboxStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/keep_settings_visible" />
-
-            </RelativeLayout>
-        </LinearLayout>
-
-        <TextView
-            android:id="@+id/settings_shutter_label"
-            style="@style/SettingsSectionLabelStyle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/shutter" />
-
-        <LinearLayout
-            android:id="@+id/settings_shutter_holder"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/medium_margin"
-            android:background="@drawable/section_holder_stroke"
-            android:orientation="vertical">
-
-            <RelativeLayout
-                android:id="@+id/settings_sound_holder"
-                style="@style/SettingsHolderCheckboxStyle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@drawable/ripple_top_corners">
-
-                <com.simplemobiletools.commons.views.MyAppCompatCheckbox
-                    android:id="@+id/settings_sound"
-                    style="@style/SettingsCheckboxStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/shutter_sound" />
-
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:id="@+id/settings_volume_buttons_as_shutter_holder"
-                style="@style/SettingsHolderCheckboxStyle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@drawable/ripple_bottom_corners">
-
-                <com.simplemobiletools.commons.views.MyAppCompatCheckbox
-                    android:id="@+id/settings_volume_buttons_as_shutter"
-                    style="@style/SettingsCheckboxStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/volume_buttons_as_shutter" />
-
-            </RelativeLayout>
-        </LinearLayout>
-
-        <TextView
-            android:id="@+id/settings_saving_label"
-            style="@style/SettingsSectionLabelStyle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/saving_label" />
-
-        <LinearLayout
-            android:id="@+id/settings_saving_holder"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/medium_margin"
-            android:background="@drawable/section_holder_stroke"
-            android:orientation="vertical">
-
-            <RelativeLayout
-                android:id="@+id/settings_save_photo_metadata_holder"
-                style="@style/SettingsHolderCheckboxStyle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@drawable/ripple_top_corners">
-
-                <com.simplemobiletools.commons.views.MyAppCompatCheckbox
-                    android:id="@+id/settings_save_photo_metadata"
-                    style="@style/SettingsCheckboxStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/save_photo_metadata" />
-
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:id="@+id/settings_flip_photos_holder"
-                style="@style/SettingsHolderCheckboxStyle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@drawable/ripple_background">
-
-                <com.simplemobiletools.commons.views.MyAppCompatCheckbox
-                    android:id="@+id/settings_flip_photos"
-                    style="@style/SettingsCheckboxStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/flip_front_camera_photos_horizontally" />
-
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:id="@+id/settings_save_photos_holder"
-                style="@style/SettingsHolderTextViewStyle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@drawable/ripple_background">
-
-                <com.simplemobiletools.commons.views.MyTextView
-                    android:id="@+id/settings_save_photos_label"
-                    style="@style/SettingsTextLabelStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/save_photos" />
-
-                <com.simplemobiletools.commons.views.MyTextView
-                    android:id="@+id/settings_save_photos"
-                    style="@style/SettingsTextValueStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_below="@+id/settings_save_photos_label"
-                    tools:text="Internal/DCIM" />
-
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:id="@+id/settings_photo_quality_holder"
-                style="@style/SettingsHolderTextViewStyle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@drawable/ripple_bottom_corners">
-
-                <com.simplemobiletools.commons.views.MyTextView
-                    android:id="@+id/settings_photo_quality_label"
-                    style="@style/SettingsTextLabelStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/photo_compression_quality" />
-
-                <com.simplemobiletools.commons.views.MyTextView
-                    android:id="@+id/settings_photo_quality"
-                    style="@style/SettingsTextValueStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_below="@+id/settings_photo_quality_label"
-                    tools:text="80%" />
-
-            </RelativeLayout>
-        </LinearLayout>
-    </LinearLayout>
-</ScrollView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## Notes
- pass rotated resolution to `ImageCaptureUsecase`, this fixes the issue when CameraX does not apply the set target resolution 
- filter supported resolutions so `0MP` resolutions are not selected. `CameraX` cannot apply these resolutions
- store and use the resolution index in `Config` class for video capture
- update `commons` and `camerax` versions in `build.gradle`
- fix getting video quality