### PR TITLE
FIX: hide last taken video icon during video recording

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/camera/extensions/View.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/extensions/View.kt
@@ -1,0 +1,12 @@
+package com.simplemobiletools.camera.extensions
+
+import android.view.View
+import com.simplemobiletools.commons.helpers.SHORT_ANIMATION_DURATION
+
+fun View.fadeIn() {
+    animate().alpha(1f).setDuration(SHORT_ANIMATION_DURATION).withStartAction { isClickable = true }.start()
+}
+
+fun View.fadeOut() {
+    animate().alpha(0f).setDuration(SHORT_ANIMATION_DURATION).withEndAction { isClickable = false }.start()
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -111,8 +111,8 @@
         android:contentDescription="@string/shutter"
         android:src="@drawable/ic_shutter_animated"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/last_photo_video_preview"
-        app:layout_constraintStart_toEndOf="@id/toggle_camera"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintVertical_bias="1" />
 
     <ImageView


### PR DESCRIPTION
# Notes
- remove unused methods in MainActivity
- fade out/in the toggle_camera and last_photo_video_preview buttons when video recording is started/stopped