### PR TITLE
disable flinging on preview view

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreview.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreview.kt
@@ -31,7 +31,6 @@ import com.simplemobiletools.camera.models.MySize
 import com.simplemobiletools.camera.models.ResolutionOption
 import com.simplemobiletools.commons.extensions.toast
 import com.simplemobiletools.commons.helpers.ensureBackgroundThread
-import kotlin.math.abs
 
 class CameraXPreview(
     private val activity: AppCompatActivity,
@@ -46,7 +45,6 @@ class CameraXPreview(
         // Auto focus is 1/6 of the area.
         private const val AF_SIZE = 1.0f / 6.0f
         private const val AE_SIZE = AF_SIZE * 1.5f
-        private const val MIN_SWIPE_DISTANCE_X = 100
     }
 
     private val config = activity.config
@@ -292,21 +290,6 @@ class CameraXPreview(
                     listener.onFocusCamera(xPos, yPos)
                     true
                 } ?: false
-            }
-
-            override fun onFling(event1: MotionEvent, event2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
-                val deltaX = event1.x - event2.x
-                val deltaXAbs = abs(deltaX)
-
-                if (deltaXAbs >= MIN_SWIPE_DISTANCE_X) {
-                    if (deltaX > 0) {
-                        listener.onSwipeLeft()
-                    } else {
-                        listener.onSwipeRight()
-                    }
-                }
-
-                return true
             }
         })
         previewView.setOnTouchListener { _, event ->

--- a/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreviewListener.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreviewListener.kt
@@ -18,8 +18,6 @@ interface CameraXPreviewListener {
     fun onVideoRecordingStopped()
     fun onVideoDurationChanged(durationNanos: Long)
     fun onFocusCamera(xPos: Float, yPos: Float)
-    fun onSwipeLeft()
-    fun onSwipeRight()
     fun onTouchPreview()
     fun displaySelectedResolution(resolutionOption: ResolutionOption)
     fun showImageSizes(


### PR DESCRIPTION
# Notes 
- only change camera mode when the fling happens on the bottom tab
- so zoom gestures do not interfere with the fling