### PR TITLE
Update CameraX to 1.2.0-rc01

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1"
     implementation 'androidx.window:window:1.1.0-alpha03'
 
-    def camerax_version = '1.2.0-beta01'
+    def camerax_version = '1.2.0-rc01'
     implementation "androidx.camera:camera-core:$camerax_version"
     implementation "androidx.camera:camera-camera2:$camerax_version"
     implementation "androidx.camera:camera-video:$camerax_version"

--- a/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreview.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreview.kt
@@ -196,8 +196,6 @@ class CameraXPreview(
                 captureUseCase,
             )
         }
-
-        previewUseCase.setSurfaceProvider(previewView.surfaceProvider)
         preview = previewUseCase
         setupZoomAndFocus()
         setFlashlightState(config.flashlightState)
@@ -215,7 +213,9 @@ class CameraXPreview(
         return Preview.Builder()
             .setTargetRotation(rotation)
             .setTargetResolution(resolution)
-            .build()
+            .build().apply {
+                setSurfaceProvider(previewView.surfaceProvider)
+            }
     }
 
     private fun getCaptureUseCase(resolution: Size, rotation: Int): UseCase {


### PR DESCRIPTION
# Notes
- update the `CameraX` version to `1.2.0-rc01`
- fix the [issue](https://github.com/SimpleMobileTools/Simple-Camera/pull/370#discussion_r1030535485) where the camera cannot be configured on some devices
- set the `PreviewView`  useCase surface provider before binding to the camera