### PR TITLE
Preview alignment improvements

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
@@ -374,7 +374,6 @@ class MainActivity : SimpleActivity(), PhotoProcessor.MediaSavedListener, Camera
             }
 
             override fun onFling(event1: MotionEvent?, event2: MotionEvent?, velocityX: Float, velocityY: Float): Boolean {
-                // these can be null even if the docs say they cannot, getting event1.x in itself can cause crashes
                 if (event1 == null || event2 == null) {
                     return true
                 }

--- a/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
@@ -11,6 +11,7 @@ import android.os.Bundle
 import android.provider.MediaStore
 import android.view.*
 import android.widget.LinearLayout
+import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.content.ContextCompat
 import androidx.core.view.*
 import androidx.transition.*
@@ -318,7 +319,9 @@ class MainActivity : SimpleActivity(), PhotoProcessor.MediaSavedListener, Camera
             initInPhotoMode = isInPhotoMode,
         )
 
-        mFocusCircleView = FocusCircleView(this)
+        mFocusCircleView = FocusCircleView(this).apply {
+            id = View.generateViewId()
+        }
         view_holder.addView(mFocusCircleView)
 
         setupPreviewImage(true)
@@ -750,6 +753,19 @@ class MainActivity : SimpleActivity(), PhotoProcessor.MediaSavedListener, Camera
         val states = arrayOf(intArrayOf(-android.R.attr.state_checked), intArrayOf(android.R.attr.state_checked))
         val iconColors = intArrayOf(ContextCompat.getColor(this, R.color.md_grey_white), primaryColor)
         button.iconTint = ColorStateList(states, iconColors)
+    }
+
+    override fun adjustPreviewView(requiresCentering: Boolean) {
+        val constraintSet = ConstraintSet()
+        constraintSet.clone(view_holder)
+        if (requiresCentering) {
+            constraintSet.connect(preview_view.id, ConstraintSet.TOP, top_options.id, ConstraintSet.BOTTOM)
+            constraintSet.connect(preview_view.id, ConstraintSet.BOTTOM, camera_mode_tab.id, ConstraintSet.TOP)
+        } else {
+            constraintSet.connect(preview_view.id, ConstraintSet.TOP, ConstraintSet.PARENT_ID, ConstraintSet.TOP)
+            constraintSet.connect(preview_view.id, ConstraintSet.BOTTOM, ConstraintSet.PARENT_ID, ConstraintSet.BOTTOM)
+        }
+        constraintSet.applyTo(view_holder)
     }
 
     override fun mediaSaved(path: String) {

--- a/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
@@ -366,20 +366,16 @@ class MainActivity : SimpleActivity(), PhotoProcessor.MediaSavedListener, Camera
 
     @SuppressLint("ClickableViewAccessibility")
     private fun initModeSwitcher() {
-        val gestureDetector = GestureDetectorCompat(this, object : GestureDetector.SimpleOnGestureListener() {
+        val gestureDetector = GestureDetectorCompat(this, object : GestureDetectorListener() {
             override fun onDown(e: MotionEvent): Boolean {
                 // we have to return true here so ACTION_UP
                 // (and onFling) can be dispatched
                 return true
             }
 
-            override fun onFling(event1: MotionEvent, event2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
+            override fun onFling(event1: MotionEvent?, event2: MotionEvent?, velocityX: Float, velocityY: Float): Boolean {
                 // these can be null even if the docs say they cannot, getting event1.x in itself can cause crashes
-                try {
-                    if (event1 == null || event2 == null || event1.x == null || event2.x == null) {
-                        return true
-                    }
-                } catch (e: NullPointerException) {
+                if (event1 == null || event2 == null) {
                     return true
                 }
 

--- a/app/src/main/kotlin/com/simplemobiletools/camera/helpers/GestureDetectorListener.java
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/helpers/GestureDetectorListener.java
@@ -1,0 +1,13 @@
+package com.simplemobiletools.camera.helpers;
+
+import android.view.GestureDetector;
+import android.view.MotionEvent;
+
+import androidx.annotation.Nullable;
+
+public class GestureDetectorListener extends GestureDetector.SimpleOnGestureListener {
+    @Override
+    public boolean onFling(@Nullable MotionEvent e1, @Nullable MotionEvent e2, float velocityX, float velocityY) {
+        return super.onFling(e1, e2, velocityX, velocityY);
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreview.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreview.kt
@@ -162,6 +162,8 @@ class CameraXPreview(
             MySize(selectedQuality.width, selectedQuality.height)
         }
 
+        listener.adjustPreviewView(resolution.requiresCentering())
+
         val isFullSize = resolution.isFullScreen
         previewView.scaleType = if (isFullSize) ScaleType.FILL_CENTER else ScaleType.FIT_CENTER
         val rotation = previewView.display.rotation

--- a/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreviewListener.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/implementations/CameraXPreviewListener.kt
@@ -29,6 +29,6 @@ interface CameraXPreviewListener {
         isFrontCamera: Boolean,
         onSelect: (index: Int, changed: Boolean) -> Unit,
     )
-
     fun showFlashOptions(photoCapture: Boolean)
+    fun adjustPreviewView(requiresCentering: Boolean)
 }

--- a/app/src/main/kotlin/com/simplemobiletools/camera/models/MySize.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/models/MySize.kt
@@ -17,6 +17,10 @@ data class MySize(val width: Int, val height: Int, val isFullScreen: Boolean = f
 
     val megaPixels: String = String.format("%.1f", (width * height.toFloat()) / ONE_MEGA_PIXEL)
 
+    fun requiresCentering(): Boolean {
+        return !isFullScreen && (isFourToThree() || isThreeToTwo() || isSquare())
+    }
+
     fun isSixteenToNine() = ratio == 16 / 9f
 
     private fun isFiveToThree() = ratio == 5 / 3f

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,7 +11,9 @@
     <androidx.camera.view.PreviewView
         android:id="@+id/preview_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <View
         android:id="@+id/shutter_animation"


### PR DESCRIPTION
# Notes
- improve preview alignments
- centre the `PreviewView` between the top action icons and the bottom mode switcher view for `4:3`, `3:2` (video mode - `SD`) and `1:1` resolutions, when not full screen
- fix `NullPointerException` thrown in the `GestureDetector` listener`onFling`. The reason why it happens even though we added the null checks and caught exception is this: 

The `GestureDetector.SimpleOnGestureListener` class is in Java and the `MotionEvent` parameters to `onFling` are marked as `@NonNull`. When used in a Kotlin file, the compiler will add `Instrisincs.checkNotNullParameter` checks before our code and this is what causes the crash

<img width="1084" alt="Screenshot 2022-11-14 at 19 34 59" src="https://user-images.githubusercontent.com/25648077/201749802-9b08f38e-44e9-4b33-8692-8d1a08988f29.png">

<img width="1473" alt="Screenshot 2022-11-25 at 07 58 41" src="https://user-images.githubusercontent.com/25648077/204090540-46d3e42f-bce3-4ea2-b364-631d1fd580e3.png">


To fix it, we have to create `GestureDetectorListener`, a Java wrapper file for the `SimpleOnGestureListener` class and mark the parameters as `@Nullable`. So now, the Kotlin compiler will not add these non-null checks. 

<img width="1243" alt="Screenshot 2022-11-26 at 13 06 03" src="https://user-images.githubusercontent.com/25648077/204090526-7e038f16-2769-45bd-8014-721e8aee2ab6.png">
