### PR TITLE
Start recording anyway when shutter sound fails

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/camera/helpers/MediaActionSound.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/helpers/MediaActionSound.kt
@@ -152,6 +152,7 @@ class MediaActionSound(private val context: Context) {
                     val soundId = loadSound(sound)
                     if (soundId <= 0) {
                         Log.e(TAG, "play() error loading sound: $mediaSound")
+                        onPlayComplete?.invoke()
                     } else {
                         sound.state = STATE_LOADING_PLAY_REQUESTED
                     }


### PR DESCRIPTION
On some devices (Samsung etc.) where there is no `VideoRecord.ogg`, recording never starts and the app is just stuck. This PR fixes that.